### PR TITLE
feat: async language support

### DIFF
--- a/src/LanguageFilterMenuButton.tsx
+++ b/src/LanguageFilterMenuButton.tsx
@@ -12,7 +12,6 @@ import {
 } from '@sanity/ui'
 import React, {FormEvent, MouseEventHandler, useCallback, useState} from 'react'
 import styled from 'styled-components'
-import {LanguageFilterConfig} from './types'
 import {usePaneLanguages} from './usePaneLanguages'
 import {
   CheckmarkCircleIcon,
@@ -22,17 +21,14 @@ import {
   TranslateIcon,
 } from '@sanity/icons'
 import {TextWithTone} from 'sanity'
+import {useLanguageFilterStudioContext} from './LanguageFilterStudioContext'
 
 const StyledBox = styled(Box)`
   max-height: calc(100vh - 200px);
 `
 
-export interface LanguageFilterMenuButtonProps {
-  options: LanguageFilterConfig
-}
-
-export function LanguageFilterMenuButton(props: LanguageFilterMenuButtonProps) {
-  const {options} = props
+export function LanguageFilterMenuButton() {
+  const {options} = useLanguageFilterStudioContext()
 
   const defaultLanguages = options.supportedLanguages.filter((l) =>
     options.defaultLanguages?.includes(l.id)
@@ -41,7 +37,7 @@ export function LanguageFilterMenuButton(props: LanguageFilterMenuButtonProps) {
   const languageOptions = options.supportedLanguages.filter(
     (l) => !options.defaultLanguages?.includes(l.id)
   )
-  const [open, setOpen] = useState(!false)
+  const [open, setOpen] = useState(false)
   const {activeLanguages, allSelected, selectAll, selectNone, toggleLanguage} = usePaneLanguages()
   const [button, setButton] = useState<HTMLElement | null>(null)
   const [popover, setPopover] = useState<HTMLElement | null>(null)
@@ -76,6 +72,8 @@ export function LanguageFilterMenuButton(props: LanguageFilterMenuButtonProps) {
       setQuery(``)
     }
   }, [])
+
+  const showSearch = langCount > 4
 
   const content = (
     <StyledBox overflow="auto">
@@ -112,11 +110,11 @@ export function LanguageFilterMenuButton(props: LanguageFilterMenuButtonProps) {
           </Flex>
         </Button>
 
-        <Card borderTop />
-
-        {langCount > 4 ? (
+        {showSearch ? (
           <TextInput onChange={handleQuery} value={query} placeholder="Filter languages" />
-        ) : null}
+        ) : (
+          <Card borderTop />
+        )}
 
         {languageOptions
           .filter((language) => {

--- a/src/LanguageFilterStudioContext.tsx
+++ b/src/LanguageFilterStudioContext.tsx
@@ -47,12 +47,6 @@ export function LanguageFilterStudioProvider(
   props: LayoutProps & LanguageFilterStudioContextProps
 ) {
   const client = useClient({apiVersion: '2023-01-01'})
-
-  // const deferredDocument = useDeferredValue(document)
-  // const selectedValue = useMemo(
-  //   () => getSelectedValue(internationalizedArray.select, deferredDocument),
-  //   [internationalizedArray.select, deferredDocument]
-  // )
   const [languages, setLanguages] = useState<Language[]>(
     Array.isArray(props.options.supportedLanguages) ? props.options.supportedLanguages : []
   )

--- a/src/getSelectedValue.ts
+++ b/src/getSelectedValue.ts
@@ -1,0 +1,29 @@
+import {get} from 'lodash'
+
+export const getSelectedValue = (
+  select: Record<string, string> | undefined,
+  document:
+    | {
+        [x: string]: unknown
+      }
+    | undefined
+): Record<string, unknown> => {
+  if (!select || !document) {
+    return {}
+  }
+
+  const selection: Record<string, string> = select || {}
+  const selectedValue: Record<string, unknown> = {}
+  for (const [key, path] of Object.entries(selection)) {
+    let value = get(document, path)
+    if (Array.isArray(value)) {
+      // If there are references in the array, ensure they have `_ref` set, otherwise they are considered empty and can safely be ignored
+      value = value.filter((item) =>
+        typeof item === 'object' ? item?._type === 'reference' && '_ref' in item : true
+      )
+    }
+    selectedValue[key] = value
+  }
+
+  return selectedValue
+}

--- a/src/plugin.tsx
+++ b/src/plugin.tsx
@@ -46,7 +46,7 @@ import {defaultContextValue, LanguageFilterStudioProvider} from './LanguageFilte
  */
 export const languageFilter = definePlugin<LanguageFilterConfig>((options) => {
   const RenderLanguageFilter: DocumentLanguageFilterComponent = () => {
-    return <LanguageFilterMenuButton options={options} />
+    return <LanguageFilterMenuButton />
   }
 
   const pluginOptions = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import {FieldMember, FieldsetState, ObjectSchemaType} from 'sanity'
+import {FieldMember, FieldsetState, ObjectSchemaType, SanityClient} from 'sanity'
 
 export interface LanguageFilterOptions {
   languageFilter?: boolean
@@ -8,10 +8,15 @@ export interface LanguageFilterSchema extends ObjectSchemaType {
   options?: LanguageFilterOptions
 }
 
-export interface Language {
-  id: string
+export type Language = {
+  id: Intl.UnicodeBCP47LocaleIdentifier
   title: string
 }
+
+export type LanguageCallback = (
+  client: SanityClient,
+  selectedValue: Record<string, unknown>
+) => Promise<Language[]>
 
 export type FilterFieldFunction = (
   enclosingType: ObjectSchemaType,
@@ -20,8 +25,17 @@ export type FilterFieldFunction = (
 ) => boolean
 
 export interface LanguageFilterConfig {
-  supportedLanguages: Language[]
+  supportedLanguages: Language[] | LanguageCallback
   defaultLanguages?: string[]
   documentTypes?: string[]
   filterField?: FilterFieldFunction
+  /**
+   * https://www.sanity.io/docs/api-versioning
+   * @defaultValue '2022-11-27'
+   */
+  apiVersion?: string
+}
+
+export interface LanguageFilterConfigProcessed extends LanguageFilterConfig {
+  supportedLanguages: Language[]
 }

--- a/src/useSelectedLanguageIds.ts
+++ b/src/useSelectedLanguageIds.ts
@@ -30,7 +30,9 @@ export function getSelectableLanguages({
   supportedLanguages,
   defaultLanguages,
 }: LanguageFilterConfig): Language[] {
-  return supportedLanguages.filter((lang) => !defaultLanguages?.includes(lang.id))
+  return Array.isArray(supportedLanguages)
+    ? supportedLanguages.filter((lang) => !defaultLanguages?.includes(lang.id))
+    : []
 }
 
 export function useSelectedLanguageIds(


### PR DESCRIPTION
Adds support for using documents as language configuration, like [Internationalized Array](https://github.com/sanity-io/sanity-plugin-internationalized-array) and [Document Internationalization](https://github.com/sanity-io/document-internationalization).