### PR TITLE
fix: prevent the plugin from filtering out 'FieldError' members

### DIFF
--- a/src/LanguageFilterObjectInput.tsx
+++ b/src/LanguageFilterObjectInput.tsx
@@ -25,7 +25,8 @@ export function FilteredObjectInput(props: ObjectInputProps) {
       .filter((member) => {
         return (
           (member.kind === 'field' && filterField(schemaType, member, selectedLanguageIds)) ||
-          member.kind === 'fieldSet'
+          member.kind === 'fieldSet' ||
+          member.kind === 'error'
         )
       })
       .map((member) => {


### PR DESCRIPTION
[ObjectMember](https://www.sanity.io/docs/reference/api/sanity/ObjectMember) has the following type declaration:
```
type ObjectMember = FieldMember | FieldSetMember | FieldError
```

[This filter expression](https://github.com/sanity-io/language-filter/blob/5193de1db192e31df261400d91ba2b1d4ef95a77/src/LanguageFilterObjectInput.tsx#L25) filters out `FieldError` members, which can cause fields to unexpectedly disappear from the UI.

This PR aims to prevent `FieldError` members from being filtered out.