### PR TITLE
fix(deps): allow studio v4 in peer dep ranges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
       },
       "peerDependencies": {
         "react": "^18 || ^19",
-        "sanity": "^3.36.4",
+        "sanity": "^3.36.4 || ^4.0.0-0",
         "styled-components": "^6.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   },
   "peerDependencies": {
     "react": "^18 || ^19",
-    "sanity": "^3.36.4",
+    "sanity": "^3.36.4 || ^4.0.0-0",
     "styled-components": "^6.1"
   },
   "engines": {


### PR DESCRIPTION
### Description

Prepping for July 15th: https://www.sanity.io/blog/a-major-version-bump-for-a-minor-reason#299526b398ec

Currently when using a package.json like: 
```json
{
  "dependencies": {
    "sanity": "4.0.0-0"
  }
}
```
Progress: resolved 1030, reused 0, downloaded 0, added 0, done
 WARN  Issues with peer dependencies found
.
└─┬ @sanity/language-filter 4.0.4
  └── ✕ unmet peer sanity@^3.36.4: found 4.0.0-0
Done in 5s using pnpm v10.12.1
```
This fixes it.

### Testing

Tested locally